### PR TITLE
fix(client): book card text overflow

### DIFF
--- a/client/src/app/books-catalogue/books-catalogue.component.scss
+++ b/client/src/app/books-catalogue/books-catalogue.component.scss
@@ -1,8 +1,8 @@
 @use '../../styles' as styles;
 
 .book-description {
-  max-height: 120px;
-  overflow: hidden;
+  max-height: 100px;
+  overflow: scroll;
 }
 
 .book-card-content {
@@ -21,7 +21,6 @@
 .book-card-title {
   display: flex;
   flex-direction: column;
-  height: 70;
 }
 
 .book-card {
@@ -39,9 +38,10 @@
 }
 
 .book-title {
-    overflow: hidden;
+    overflow: scroll;
     line-height: 24px;
     font-size: 16px;
+    max-height: 55px;
 
     a {
       color: styles.$dark-text;
@@ -99,3 +99,4 @@
     display: none;
   }
 }
+


### PR DESCRIPTION
Before:
<img width="456" alt="Screenshot 2023-11-17 at 15 38 53" src="https://github.com/mongodb-developer/library-management-system/assets/7893485/ed48c7b0-180b-4dd0-9168-67e99edeac90">


After (scrollable title and description):
<img width="456" alt="Screenshot 2023-11-17 at 15 39 20" src="https://github.com/mongodb-developer/library-management-system/assets/7893485/37abaa84-e6b6-434b-99dd-012d216477e5">


