### PR TITLE
server: send an appName parameter when opening a database connection

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -18,7 +18,7 @@ export async function connectToDatabase(uri?: string) {
         throw new Error('Database URI is not defined');
     }
 
-    const client = new mongodb.MongoClient(uri);
+    const client = new mongodb.MongoClient(uri, { appName: 'devrel.workshop.devday' });
     await client.connect();
 
     const db = client.db(process.env.DATABASE_NAME);


### PR DESCRIPTION
This PR adds an appName option when instantiating the MongoDB client. 