### PR TITLE
Rebrand Atlas Search to MongoDB Search

### DIFF
--- a/server/src/search-indexing/dynamic-mappings.ts
+++ b/server/src/search-indexing/dynamic-mappings.ts
@@ -9,9 +9,8 @@ console.log('Connected!\n');
 const collection = collections?.books;
 
 /**
- * Create the Atlas Search index with dynamic mappings.
- * Atlas will automatically infer the field types based on the data in the documents.
- * Dynamic mappings are useful when you're just getting started with Atlas Search or if your schema changes regularly.
+ * Create the MongoDB Search index with dynamic mappings.
+ * Dynamic mappings are useful when your schema changes regularly or when getting started.
  * However, they take up more space compared to static mappings.
  */
 await collection.createSearchIndex({

--- a/server/src/search-indexing/prefilter.ts
+++ b/server/src/search-indexing/prefilter.ts
@@ -9,7 +9,7 @@ console.log('Connected!\n');
 const collection = collections?.books;
 
 /**
- * Create the Vector Search index with prefiltering fields.
+ * Create the MongoDB Vector Search index with prefiltering fields.
  */
 await collection.createSearchIndex({
     name: 'vectorsearch-prefilter',

--- a/server/src/search-indexing/quantization.ts
+++ b/server/src/search-indexing/quantization.ts
@@ -9,7 +9,7 @@ console.log('Connected!\n');
 const collection = collections?.books;
 
 /**
- * Create the Vector Search index with scalar quantization.
+ * Create the MongoDB Vector Search index with scalar quantization.
  */
 await collection.createSearchIndex({
     name: 'vectorsearch-quantized',

--- a/server/src/search-indexing/vector-search.ts
+++ b/server/src/search-indexing/vector-search.ts
@@ -9,7 +9,7 @@ console.log('Connected!\n');
 const collection = collections?.books;
 
 /**
- * Create the Vector Search index.
+ * Create the MongoDB Vector Search index.
  * The index definition specifies the field that contains the vector embeddings,
  * the number of dimensions in the vectors
  * and the similarity metric to use for searching.


### PR DESCRIPTION
## Summary

- `Atlas Search` → `MongoDB Search` in full-text search comments
- `Vector Search index` → `MongoDB Vector Search index` in vector search comments
- Removed Atlas-specific description from `dynamic-mappings.ts` ("Atlas will automatically infer...")

Reflects rebranding as Full Text Search and Vector Search expand beyond Atlas to Enterprise and Community tiers.