### PR TITLE
Add score display utils for search lab

### DIFF
--- a/server/src/controllers/books.ts
+++ b/server/src/controllers/books.ts
@@ -3,6 +3,8 @@ import { Book } from '../models/book';
 import { collections } from '../database.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import getEmbeddings from '../embeddings/index.js';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { searchScoreStage, vectorScoreStage, hybridScoreStage } from '../utils/score-display.js';
 
 class BookController {
     errors = {

--- a/server/src/utils/score-display.ts
+++ b/server/src/utils/score-display.ts
@@ -1,0 +1,92 @@
+/**
+ * Aggregation stage helpers for displaying search scores in the synopsis field.
+ *
+ * Usage in books.ts:
+ *
+ *   import { searchScoreStage, vectorScoreStage, hybridScoreStage } from '../utils/score-display.js';
+ *
+ *   // Full-text search:   [..., searchScoreStage]
+ *   // Vector search:      [..., vectorScoreStage]
+ *   // Hybrid search:      [..., hybridScoreStage]  (requires scoreDetails: true)
+ */
+
+/** Prepends the $search relevance score to the synopsis. */
+export const searchScoreStage = {
+    $addFields: {
+        synopsis: {
+            $concat: [
+                '[score: ', { $toString: { $round: [{ $meta: 'searchScore' }, 4] } }, ']\n',
+                { $ifNull: ['$synopsis', ''] }
+            ]
+        }
+    }
+};
+
+/** Prepends the $vectorSearch similarity score to the synopsis. */
+export const vectorScoreStage = {
+    $addFields: {
+        synopsis: {
+            $concat: [
+                '[score: ', { $toString: { $round: [{ $meta: 'vectorSearchScore' }, 4] } }, ']\n',
+                { $ifNull: ['$synopsis', ''] }
+            ]
+        }
+    }
+};
+
+/**
+ * Prepends the combined + per-pipeline scores to the synopsis.
+ * Requires `scoreDetails: true` in the $scoreFusion or $rankFusion stage.
+ */
+export const hybridScoreStage = {
+    $addFields: {
+        synopsis: {
+            $let: {
+                vars: {
+                    sd: { $meta: 'scoreDetails' },
+                    sem: {
+                        $arrayElemAt: [
+                            {
+                                $filter: {
+                                    input: {
+                                        $ifNull: [
+                                            { $getField: { field: 'details', input: { $meta: 'scoreDetails' } } },
+                                            []
+                                        ]
+                                    },
+                                    cond: { $eq: ['$$this.inputPipelineName', 'semanticSearch'] }
+                                }
+                            },
+                            0
+                        ]
+                    },
+                    lex: {
+                        $arrayElemAt: [
+                            {
+                                $filter: {
+                                    input: {
+                                        $ifNull: [
+                                            { $getField: { field: 'details', input: { $meta: 'scoreDetails' } } },
+                                            []
+                                        ]
+                                    },
+                                    cond: { $eq: ['$$this.inputPipelineName', 'lexicalSearch'] }
+                                }
+                            },
+                            0
+                        ]
+                    }
+                },
+                in: {
+                    $concat: [
+                        '[combined: ', { $toString: { $round: ['$$sd.value', 4] } },
+                        ' | sem: ', { $toString: { $round: [{ $ifNull: ['$$sem.inputPipelineRawScore', 0] }, 4] } },
+                        ' | lex: ', { $toString: { $round: [{ $ifNull: ['$$lex.inputPipelineRawScore', 0] }, 4] } },
+                        ']\n',
+                        { $ifNull: ['$synopsis', ''] }
+                    ]
+                }
+            }
+        }
+    }
+};


### PR DESCRIPTION
Adds aggregation stage helpers that prepend search scores to the `synopsis` field, used by the Instruqt search workshop for live score debugging in the Library Application UI.

## What

`server/src/utils/score-display.ts` exports three reusable aggregation stages:

- **`searchScoreStage`** -- prepends `[score: ...]` from `$meta: 'searchScore'`
- **`vectorScoreStage`** -- prepends `[score: ...]` from `$meta: 'vectorSearchScore'`
- **`hybridScoreStage`** -- prepends `[combined: ... | sem: ... | lex: ...]` from `scoreDetails` metadata (requires `scoreDetails: true` in `$scoreFusion`/`$rankFusion`)

`server/src/controllers/books.ts` gets an import line (unused by default, wired up during the lab).

## Why

Requested in [mongodb-developer/devrel-instruqt-labs#83](https://github.com/mongodb-developer/devrel-instruqt-labs/pull/83) to keep the Instruqt assignment code snippets clean by moving complex `$addFields` expressions out of inline lab instructions.